### PR TITLE
Use outfile name while downloading binary

### DIFF
--- a/ci/scripts/download-cf-cli-binary.sh
+++ b/ci/scripts/download-cf-cli-binary.sh
@@ -39,7 +39,7 @@ download_cf_cli_binary() {
   echo "Downloading CF CLI ${_major_version} to directory ${_resolved_output_dir}"
 
   wget --trust-server-names \
-    --directory-prefix "${_resolved_output_dir}" \
+    --output-document="${_resolved_output_dir}/cf${_major_version}-cli_${_major_version}._linux_x86-64.tgz" \
     --no-verbose \
      "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v${_major_version}&source=bosh-package-cf-cli-release-workflow"
 


### PR DESCRIPTION
With `wget` when no output filename is given, it is taken from the destination and is exceeding the filename length. This leads to filename truncation and bosh is not able to find the file. 